### PR TITLE
Move `IncrementalState` type from shelley to core

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # "Nightly" builds: Every day at 06:00 UTC
     - cron: '0 6 * * *'
+  workflow_dispatch:
+
 # Cancel running actions when a new action on the same PR is started
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event.pull_request.draft == false }}
 
     env:
       # Modify this value to "invalidate" the cabal cache.
@@ -128,6 +129,7 @@ jobs:
 
   fourmolu:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
 
     defaults:
       run:
@@ -151,6 +153,7 @@ jobs:
 
   cabal-format:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
 
     defaults:
       run:
@@ -165,6 +168,7 @@ jobs:
       run: ./scripts/cabal-format.sh
 
   gen-hie:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     # "Nightly" builds: Every day at 06:00 UTC
     - cron: '0 6 * * *'
+# Cancel running actions when a new action on the same PR is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     # "Nightly" builds: Every day at 06:00 UTC
     - cron: '0 6 * * *'
-  workflow_dispatch:
+  workflow_dispatch: #manual
 
 # Cancel running actions when a new action on the same PR is started
 concurrency:

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -88,6 +88,7 @@ module Cardano.Ledger.Shelley.LedgerState (
 
 import Cardano.Ledger.DPState
 import Cardano.Ledger.Era (EraCrypto)
+import Cardano.Ledger.IncrementalStake
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Witness))
 import Cardano.Ledger.Shelley.LedgerState.IncrementalStake
 import Cardano.Ledger.Shelley.LedgerState.NewEpochState

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -48,6 +48,7 @@ import Cardano.Ledger.EpochBoundary (
   SnapShot (..),
   Stake (..),
  )
+import Cardano.Ledger.IncrementalStake (IncrementalStake (..))
 import Cardano.Ledger.Keys (
   KeyRole (..),
  )

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.DPState (
   DState (..),
   InstantaneousRewards (..),
  )
+import Cardano.Ledger.IncrementalStake (IncrementalStake (..))
 import Cardano.Ledger.Keys (
   GenDelegPair (..),
   GenDelegs (..),

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -42,6 +42,7 @@ library
         Cardano.Ledger.Era
         Cardano.Ledger.Hashes
         Cardano.Ledger.HKD
+        Cardano.Ledger.IncrementalStake
         Cardano.Ledger.Keys
         Cardano.Ledger.Keys.Bootstrap
         Cardano.Ledger.Keys.WitVKey

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/IncrementalStake.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/IncrementalStake.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Cardano.Ledger.IncrementalStake (
+  IncrementalStake (..),
+) where
+
+import Cardano.Ledger.Binary (
+  DecCBOR (decCBOR),
+  DecShareCBOR (Share, decShareCBOR),
+  EncCBOR (encCBOR),
+  Interns,
+  decodeRecordNamed,
+  encodeListLen,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (Credential (..), Ptr (..))
+import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Keys (
+  -- deprecated
+  KeyRole (..),
+ )
+import Cardano.Ledger.TreeDiff (ToExpr)
+import Control.DeepSeq (NFData)
+import Data.Default.Class (Default, def)
+import Data.Group (Group, invert)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+-- | Incremental Stake, Stake along with possible missed coins from danging Ptrs.
+--   Transactions can use Ptrs to refer to a stake credential in a TxOut. The Ptr
+--   does not have to point to anything until the epoch boundary, when we compute
+--   rewards and aggregate staking information for ranking. This is unusual but legal.
+--   In a non incremental system, we use whatever 'legal' Ptrs exist at the epoch
+--   boundary. Here we are computing things incrementally, so we need to remember Ptrs
+--   that might point to something by the time the epoch boundary is reached. When
+--   the epoch boundary is reached we 'resolve' these pointers, to see if any have
+--   become non-dangling since the time they were first used in the incremental computation.
+data IncrementalStake c = IStake
+  { credMap :: !(Map (Credential 'Staking c) Coin)
+  , ptrMap :: !(Map Ptr Coin)
+  }
+  deriving (Generic, Show, Eq, Ord, NoThunks, NFData)
+
+instance Crypto c => EncCBOR (IncrementalStake c) where
+  encCBOR (IStake st dangle) =
+    encodeListLen 2 <> encCBOR st <> encCBOR dangle
+
+instance Crypto c => DecShareCBOR (IncrementalStake c) where
+  type Share (IncrementalStake c) = Interns (Credential 'Staking c)
+  decShareCBOR credInterns =
+    decodeRecordNamed "Stake" (const 2) $ do
+      stake <- decShareCBOR (credInterns, mempty)
+      IStake stake <$> decCBOR
+
+instance Semigroup (IncrementalStake c) where
+  (IStake a b) <> (IStake c d) = IStake (Map.unionWith (<>) a c) (Map.unionWith (<>) b d)
+
+instance Monoid (IncrementalStake c) where
+  mempty = IStake Map.empty Map.empty
+
+instance Data.Group.Group (IncrementalStake c) where
+  invert (IStake m1 m2) = IStake (Map.map invert m1) (Map.map invert m2)
+
+instance Default (IncrementalStake c) where
+  def = IStake Map.empty Map.empty
+
+instance ToExpr (IncrementalStake c)


### PR DESCRIPTION
so it's accessible in EpochBoundary for era translation

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-ledger/blob/master/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [ ] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [ ] `hie.yaml` has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
